### PR TITLE
@YassLab が法人成りしたので各種情報を更新しました

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -11,7 +11,7 @@ Technology companies that allow remote work in Japan.
 | [MMM](http://mmmcorp.co.jp/) | Design and Implementation support of AWS services, website design and development. | :ok_hand: |
 | [Increments](http://increments.co.jp/) | Website planning, development and management. For example, [Qiita](http://qiita.com) The website for programmers. | :ok_hand: |
 | [パシフィックポーター株式会社](http://pacificporter.jp/) | Developing「[かんざし](https://kanzashi.com/)」, Reservation and Customer Manager System for Beauty Salon. | |
-| [YassLab](http://yasslab.jp/en/) | Agile web development support with Ruby/Rails, management of Japanese [Rails Tutorial](http://railstutorial.jp)/[Rails Guides](http://railsguides.jp), and development of [Continuous Translation System](https://speakerdeck.com/yasulab/how-we-continuously-translate-tech-docs) | :ok_hand: |
+| [YassLab Inc.](https://yasslab.jp/en/) | Agile web development support with Ruby/Rails, management of Japanese [Rails Tutorial](https://railstutorial.jp)/[Rails Guides](https://railsguides.jp), and development of [Continuous Translation System](https://speakerdeck.com/yasulab/how-we-continuously-translate-tech-docs) | :ok_hand: |
 | [HeartRails Inc.](http://www.heartrails.com/) | Planning and development of web services and smartphone apps for new business. | :ok_hand: |
 | [かなめい株式会社](http://kanamei.co.jp/) | Website planning, development and management. Mobile content focus. | |
 | [co-meeting](http://www.co-meeting.co.jp/) | Developing Crowy, BBS site co-meeting and Salesforse apps. Staff can choose how they work, timezone and day of the week. | |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Technology companies that allow remote work in Japan.
 | [MMM](http://mmmcorp.co.jp/) | AWS設計・導入支援や、Webサービスの設計・開発などを行う開発会社。社員全員がリモートワーク。 | :ok_hand: |
 | [Increments](http://increments.co.jp/) | プログラマ向けWebサービス「[Qiita](http://qiita.com)」等の企画・開発・運営 | :ok_hand: |
 | [パシフィックポーター株式会社](http://pacificporter.jp/) | 美容室予約サイトの一元管理システム「[かんざし](https://kanzashi.com/)」の開発運営 | |
-| [YassLab](http://yasslab.jp/) | Rubyを使ったアジャイル開発の支援、[Railsチュートリアル](http://railstutorial.jp)/[Railsガイド](http://railsguides.jp)の運営、[継続的翻訳システム](https://speakerdeck.com/yasulab/how-we-continuously-translate-tech-docs)の開発 | :ok_hand: |
+| [YassLab 株式会社](https://yasslab.jp/ja/) | Rubyを使ったアジャイル開発の支援、[Railsチュートリアル](https://railstutorial.jp)/[Railsガイド](https://railsguides.jp)の運営、[継続的翻訳システム](https://speakerdeck.com/yasulab/how-we-continuously-translate-tech-docs)の開発 | :ok_hand: |
 | [HeartRails Inc.](http://www.heartrails.com/) | 新規事業に伴うウェブサービス・スマホアプリ専門の企画開発会社。社員全員がリモートワーク。 | :ok_hand: |
 | [かなめい株式会社](http://kanamei.co.jp/) | ウェブアプリケーション企画・制作・運営、モバイル向けコンテンツ制作 | |
 | [co-meeting](http://www.co-meeting.co.jp/) | Crowy・掲示板サイトco-meeting・Salesforceのアプリ開発会社。リモート勤務・時間・曜日選択可能。 | |


### PR DESCRIPTION
2018年1月11日に法人成りしました ;) 
https://github.com/yasslab

- 旧: YassLab
- 新: YassLab 株式会社 (YassLab Inc.)

自社情報の更新なので、明日あたりにマージしちゃいますね 🔧 💨 